### PR TITLE
fix: profile dropdown with OAuth token for submissions

### DIFF
--- a/src/app/api/my-submissions/route.ts
+++ b/src/app/api/my-submissions/route.ts
@@ -22,7 +22,8 @@ export async function GET() {
   const email = session.user.email;
   const name = session.user.name;
 
-  if (!process.env.GITHUB_TOKEN) {
+  const token = (session as { accessToken?: string }).accessToken || process.env.GITHUB_TOKEN;
+  if (!token) {
     return NextResponse.json({ error: 'GitHub integration not configured' }, { status: 503 });
   }
 
@@ -31,7 +32,7 @@ export async function GET() {
       'https://api.github.com/repos/sehoon787/agent-hub/issues?labels=agent-submission&state=all&per_page=100',
       {
         headers: {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Authorization: `Bearer ${token}`,
           Accept: 'application/vnd.github.v3+json',
         },
         next: { revalidate: 60 },

--- a/src/app/submit/submit-form.tsx
+++ b/src/app/submit/submit-form.tsx
@@ -122,11 +122,11 @@ export function SubmitForm() {
     });
   }, [form.description, form.tags, form.capabilities, form.tools, form.model, form.category]);
 
-  // Auto-fill author from GitHub login (username)
+  // Auto-fill author from GitHub login (username) on mount
   useEffect(() => {
     const login = session?.user?.login;
     if (login) {
-      setForm((prev) => prev.author ? prev : { ...prev, author: login });
+      setForm((prev) => ({ ...prev, author: login }));
     }
   }, [session?.user?.login]);
 
@@ -368,16 +368,9 @@ export function SubmitForm() {
             )}
           </select>
         </div>
-        <div>
-          <label className="text-sm font-medium text-zinc-300">Author</label>
-          <Input
-            value={form.author}
-            readOnly
-            className="mt-1 border-zinc-700 bg-zinc-800/50 text-zinc-100 opacity-70 cursor-not-allowed"
-          />
-          <p className="mt-1 text-xs text-zinc-500">Auto-filled from your GitHub account</p>
-          {fieldErrors.author && <p className="mt-1 text-xs text-red-400">{fieldErrors.author[0]}</p>}
-        </div>
+        {fieldErrors.author && (
+          <p className="text-xs text-red-400">{fieldErrors.author[0]}</p>
+        )}
         <div>
           <label className="text-sm font-medium text-zinc-300">GitHub URL</label>
           <Input

--- a/src/components/auth/auth-button.tsx
+++ b/src/components/auth/auth-button.tsx
@@ -1,11 +1,25 @@
 "use client"
 
 import Image from "next/image"
+import Link from "next/link"
 import { useSession, signIn, signOut } from "next-auth/react"
-import { LogIn, LogOut } from "lucide-react"
+import { LogIn, LogOut, FileText } from "lucide-react"
+import { useState, useRef, useEffect } from "react"
 
 export function AuthButton() {
   const { data: session, status } = useSession()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
 
   if (status === "loading") {
     return (
@@ -15,26 +29,54 @@ export function AuthButton() {
 
   if (session?.user) {
     return (
-      <div className="flex items-center gap-2">
-        {session.user.image && (
-          <Image
-            src={session.user.image}
-            alt={session.user.name ?? "User"}
-            width={28}
-            height={28}
-            className="h-7 w-7 rounded-full"
-          />
-        )}
-        <span className="hidden text-sm text-zinc-300 sm:inline">
-          {session.user.name}
-        </span>
+      <div className="relative" ref={ref}>
         <button
-          onClick={() => signOut()}
-          className="rounded-md p-1.5 text-zinc-400 hover:text-zinc-100"
-          aria-label="Sign out"
+          onClick={() => setOpen((prev) => !prev)}
+          className="flex items-center gap-2 rounded-full p-0.5 hover:ring-2 hover:ring-zinc-600 transition-all"
+          aria-label="User menu"
         >
-          <LogOut className="h-4 w-4" />
+          {session.user.image ? (
+            <Image
+              src={session.user.image}
+              alt={session.user.name ?? "User"}
+              width={32}
+              height={32}
+              className="h-8 w-8 rounded-full"
+            />
+          ) : (
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-violet-600 text-sm font-medium text-white">
+              {(session.user.name ?? "U")[0].toUpperCase()}
+            </div>
+          )}
         </button>
+
+        {open && (
+          <div className="absolute right-0 mt-2 w-56 rounded-xl border border-zinc-800 bg-zinc-950 py-1 shadow-xl z-50">
+            <div className="border-b border-zinc-800 px-4 py-3">
+              <p className="text-sm font-medium text-zinc-100 truncate">
+                {session.user.name}
+              </p>
+              <p className="text-xs text-zinc-500 truncate">
+                {session.user.login ?? session.user.email}
+              </p>
+            </div>
+            <Link
+              href="/my-submissions"
+              onClick={() => setOpen(false)}
+              className="flex w-full items-center gap-2.5 px-4 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800/50 transition-colors"
+            >
+              <FileText className="h-4 w-4 text-zinc-500" />
+              My Submissions
+            </Link>
+            <button
+              onClick={() => { setOpen(false); signOut(); }}
+              className="flex w-full items-center gap-2.5 px-4 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800/50 transition-colors"
+            >
+              <LogOut className="h-4 w-4 text-zinc-500" />
+              Sign out
+            </button>
+          </div>
+        )}
       </div>
     )
   }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,22 +4,20 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Bot, Menu, X } from 'lucide-react';
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
+
 import { cn } from '@/lib/utils';
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@/components/ui/sheet';
 import { AuthButton } from '@/components/auth/auth-button';
 
-const navLinks: { href: string; label: string; auth?: boolean }[] = [
+const navLinks: { href: string; label: string }[] = [
   { href: '/agents', label: 'Agents' },
   { href: '/submit', label: 'Submit' },
-  { href: '/my-submissions', label: 'My Submissions', auth: true },
   { href: '/about', label: 'About' },
 ];
 
 export function Header() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
-  const { data: session } = useSession();
 
   return (
     <header className="sticky top-0 z-50 border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-md">
@@ -33,9 +31,7 @@ export function Header() {
 
         {/* Desktop nav */}
         <nav className="hidden items-center gap-1 md:flex">
-          {navLinks
-            .filter((link) => !link.auth || session?.user)
-            .map((link) => (
+          {navLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
@@ -72,9 +68,7 @@ export function Header() {
             <SheetContent side="right" className="w-64 border-zinc-800 bg-zinc-950">
               <SheetTitle className="sr-only">Navigation menu</SheetTitle>
               <nav className="mt-8 flex flex-col gap-2">
-                {navLinks
-                  .filter((link) => !link.auth || session?.user)
-                  .map((link) => (
+                {navLinks.map((link) => (
                   <Link
                     key={link.href}
                     href={link.href}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -21,15 +21,21 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     signIn: "/signin",
   },
   callbacks: {
-    jwt({ token, profile }) {
+    jwt({ token, profile, account }) {
       if (profile) {
         token.login = (profile as { login?: string }).login
+      }
+      if (account) {
+        token.accessToken = account.access_token
       }
       return token
     },
     session({ session, token }) {
       if (token.login) {
         session.user.login = token.login as string
+      }
+      if (token.accessToken) {
+        session.accessToken = token.accessToken as string
       }
       return session
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -9,5 +9,6 @@ declare module "next-auth" {
       image?: string | null
       login?: string
     }
+    accessToken?: string
   }
 }


### PR DESCRIPTION
## Summary
- **OAuth 토큰 전파**: NextAuth jwt/session 콜백을 통해 GitHub OAuth `accessToken`을 세션에 전달하여, `GITHUB_TOKEN` 환경변수 없이도 `/api/my-submissions` API가 동작하도록 수정
- **프로필 드롭다운**: AuthButton을 아바타 클릭 → 드롭다운 메뉴로 변환 (My Submissions + Sign out)
- **네비게이션 정리**: Header nav에서 "My Submissions" 제거 (프로필 드롭다운으로 이동)
- **Submit 폼 정리**: 비활성 상태의 Author 입력 필드 제거 (자동으로 GitHub ID가 채워짐)

## Changed files
| File | Change |
|------|--------|
| `src/lib/auth.ts` | jwt callback에 `account.access_token` 저장, session callback에 `accessToken` 전달 |
| `src/types/next-auth.d.ts` | Session 타입에 `accessToken` 추가 |
| `src/app/api/my-submissions/route.ts` | `session.accessToken` 우선 사용, `GITHUB_TOKEN` 폴백 |
| `src/components/auth/auth-button.tsx` | 프로필 드롭다운 메뉴 구현 (click-outside 감지) |
| `src/components/layout/header.tsx` | navLinks에서 My Submissions 제거, useSession 제거 |
| `src/app/submit/submit-form.tsx` | Author 입력 필드 UI 제거 |

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공 (112 pages generated)
- [ ] 로그인 후 아바타 클릭 → 드롭다운 메뉴 표시 확인
- [ ] My Submissions 클릭 → 제출 목록 정상 로드 확인
- [ ] Submit 페이지에서 Author 필드 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)