### PR TITLE
fix: submissions API token fallback + form validation

### DIFF
--- a/src/app/api/my-submissions/route.ts
+++ b/src/app/api/my-submissions/route.ts
@@ -22,24 +22,31 @@ export async function GET() {
   const email = session.user.email;
   const name = session.user.name;
 
-  const token = (session as { accessToken?: string }).accessToken || process.env.GITHUB_TOKEN;
-  if (!token) {
-    return NextResponse.json({ error: 'GitHub integration not configured' }, { status: 503 });
+  const token = session.accessToken || process.env.GITHUB_TOKEN;
+
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
   }
 
   try {
     const res = await fetch(
       'https://api.github.com/repos/sehoon787/agent-hub/issues?labels=agent-submission&state=all&per_page=100',
       {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github.v3+json',
-        },
+        headers,
         next: { revalidate: 60 },
       }
     );
 
     if (!res.ok) {
+      if (res.status === 403 || res.status === 401) {
+        return NextResponse.json(
+          { error: 'Session expired. Please sign out and sign back in.' },
+          { status: 401 }
+        );
+      }
       return NextResponse.json({ error: 'Failed to fetch submissions' }, { status: 502 });
     }
 

--- a/src/app/submit/submit-form.tsx
+++ b/src/app/submit/submit-form.tsx
@@ -60,7 +60,7 @@ const PLATFORM_MODELS: Record<string, string[]> = {
 };
 
 const NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
-const GITHUB_URL_RE = /^https:\/\/github\.com\/[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+/;
+const GITHUB_URL_RE = /^https:\/\/github/i;
 const AUTHOR_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
 
 const stageColors: Record<string, string> = {
@@ -155,7 +155,7 @@ export function SubmitForm() {
     if (field === 'name' && value && !NAME_RE.test(value)) {
       msg = 'Must be lowercase alphanumeric with hyphens, cannot start/end with a hyphen.';
     } else if (field === 'githubUrl' && value && !GITHUB_URL_RE.test(value)) {
-      msg = 'Must start with https://github.com/owner/repo';
+      msg = 'Must start with https://github';
     } else if (field === 'author' && value && !AUTHOR_RE.test(value)) {
       msg = 'Must be alphanumeric, may include dots, hyphens, or underscores.';
     }
@@ -280,7 +280,7 @@ export function SubmitForm() {
             onChange={(e) => update('name', e.target.value)}
             onBlur={(e) => validate('name', e.target.value)}
             placeholder="e.g. my-agent (lowercase, hyphens only)"
-            className="mt-1 border-zinc-700 bg-zinc-800/50 text-zinc-100"
+            className={`mt-1 bg-zinc-800/50 text-zinc-100 ${fieldErrors.name || clientErrors.name ? 'border-red-500' : 'border-zinc-700'}`}
           />
           {clientErrors.name && <p className="mt-1 text-xs text-red-400">{clientErrors.name}</p>}
           {fieldErrors.name && <p className="mt-1 text-xs text-red-400">{fieldErrors.name[0]}</p>}
@@ -291,7 +291,7 @@ export function SubmitForm() {
             value={form.displayName}
             onChange={(e) => update('displayName', e.target.value)}
             placeholder="e.g. My Agent"
-            className="mt-1 border-zinc-700 bg-zinc-800/50 text-zinc-100"
+            className={`mt-1 bg-zinc-800/50 text-zinc-100 ${fieldErrors.displayName ? 'border-red-500' : 'border-zinc-700'}`}
           />
           {fieldErrors.displayName && <p className="mt-1 text-xs text-red-400">{fieldErrors.displayName[0]}</p>}
         </div>
@@ -301,7 +301,7 @@ export function SubmitForm() {
             value={form.description}
             onChange={(e) => update('description', e.target.value)}
             placeholder="Brief description of what the agent does..."
-            className="mt-1 border-zinc-700 bg-zinc-800/50 text-zinc-100"
+            className={`mt-1 bg-zinc-800/50 text-zinc-100 ${fieldErrors.description ? 'border-red-500' : 'border-zinc-700'}`}
             rows={2}
           />
           {fieldErrors.description && <p className="mt-1 text-xs text-red-400">{fieldErrors.description[0]}</p>}
@@ -322,7 +322,7 @@ export function SubmitForm() {
             <select
               value={form.category}
               onChange={(e) => update('category', e.target.value)}
-              className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-800/50 px-3 py-2 text-sm text-zinc-300"
+              className={`mt-1 w-full rounded-md border bg-zinc-800/50 px-3 py-2 text-sm text-zinc-300 ${fieldErrors.category ? 'border-red-500' : 'border-zinc-700'}`}
             >
               <option value="">Select category</option>
               <option value="orchestrator">Orchestrator</option>
@@ -337,7 +337,7 @@ export function SubmitForm() {
             <select
               value={form.platform}
               onChange={(e) => handlePlatformChange(e.target.value)}
-              className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-800/50 px-3 py-2 text-sm text-zinc-300"
+              className={`mt-1 w-full rounded-md border bg-zinc-800/50 px-3 py-2 text-sm text-zinc-300 ${fieldErrors.platform ? 'border-red-500' : 'border-zinc-700'}`}
             >
               <option value="">Select platform</option>
               <option value="claude">Claude Code</option>
@@ -378,7 +378,7 @@ export function SubmitForm() {
             onChange={(e) => { update('githubUrl', e.target.value); validate('githubUrl', e.target.value); }}
             onBlur={(e) => validate('githubUrl', e.target.value)}
             placeholder="https://github.com/..."
-            className="mt-1 border-zinc-700 bg-zinc-800/50 text-zinc-100"
+            className={`mt-1 bg-zinc-800/50 text-zinc-100 ${fieldErrors.githubUrl || clientErrors.githubUrl ? 'border-red-500' : 'border-zinc-700'}`}
           />
           <p className="mt-1 text-xs text-zinc-500">Must be a GitHub URL (https://github.com/owner/repo)</p>
           {clientErrors.githubUrl && <p className="mt-1 text-xs text-red-400">{clientErrors.githubUrl}</p>}


### PR DESCRIPTION
## Summary
- **My Submissions 503 오류 해결**: `accessToken`이 없는 기존 세션에서도 public repo Issues API에 인증 없이 접근 (rate-limited fallback). 401/403 시 "재로그인" 안내 메시지 반환
- **GitHub URL 검증 완화**: `https://github.com/user/repo` 형식 강제 → `https://github`로 시작하면 통과
- **폼 에러 시각화**: 검증 실패 필드에 빨간 테두리(`border-red-500`) 추가

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [ ] 기존 세션(accessToken 없음)으로 /my-submissions 접근 → 오류 없이 로드
- [ ] Submit 폼에서 잘못된 값 입력 시 빨간 테두리 표시 확인
- [ ] GitHub URL에 `https://github.com/user/repo` 외 `https://github.io/...` 등도 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)