### PR TITLE
fix: replace regex with string matching in issue parser

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -50,9 +50,9 @@ jobs:
 
             // Parse **key:** value format from issue body
             function parseField(body, key) {
-              const regex = new RegExp('\\*\\*' + key + ':\\*\\*\\s*(.+)', 'i');
-              const match = body.match(regex);
-              return match ? match[1].trim() : '';
+              const prefix = '**' + key + ':** ';
+              const line = body.split('\\n').find(function(l) { return l.startsWith(prefix); });
+              return line ? line.slice(prefix.length).trim() : '';
             }
 
             const name = parseField(body, 'name');


### PR DESCRIPTION
## Summary
- Replace broken regex in `issue-to-pr.yml` parseField with simple string matching
- Regex `\*\*` was losing backslashes through YAML→bash→JS escaping layers
- New approach: `split('\n')` + `startsWith('**key:** ')` — no escaping needed

## Test plan
- [ ] Re-trigger Issue #27 approval after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)