### PR TITLE
fix: change cron schedules to daily for Vercel Hobby plan

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -44,15 +44,13 @@ test.describe('Homepage', () => {
     expect(count).toBeLessThanOrEqual(10)
   })
 
-  test.skip('should have platform filter tabs in compact ranking', async ({ page }) => {
-    // TODO: enable after 2-column layout deployment
+  test('should have platform filter tabs in compact ranking', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('button:has-text("All")')).toBeVisible()
     await expect(page.locator('button:has-text("claude")')).toBeVisible()
   })
 
-  test.skip('should display 2-column ranking and recent agents layout', async ({ page }) => {
-    // TODO: enable after 2-column layout deployment
+  test('should display 2-column ranking and recent agents layout', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('text=Top by Stars')).toBeVisible()
     const recentCards = page.locator('section .grid h3:has-text("Recently Added")')

--- a/vercel.json
+++ b/vercel.json
@@ -5,11 +5,11 @@
   "crons": [
     {
       "path": "/api/cron/sync-stars",
-      "schedule": "0 */6 * * *"
+      "schedule": "0 0 * * *"
     },
     {
       "path": "/api/cron/sync-news",
-      "schedule": "30 */6 * * *"
+      "schedule": "0 12 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Vercel Hobby plan only allows cron jobs that run **once per day**. The `*/6 * * *` schedules were causing deployment failures.
- `sync-stars`: changed from every 6h → daily at 00:00 UTC
- `sync-news`: changed from every 6h → daily at 12:00 UTC
- Enables 2 previously skipped E2E tests for the new 2-column layout

## Test plan

- [ ] Vercel deployment succeeds after merge
- [ ] E2E tests pass with new layout tests enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)