### PR TITLE
fix: disambiguate Recently Added locator in E2E test

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -30,7 +30,7 @@ test.describe('Homepage', () => {
 
   test('should display recently added section', async ({ page }) => {
     await page.goto('/')
-    await expect(page.locator('text=Recently Added')).toBeVisible()
+    await expect(page.locator('text=Recently Added').first()).toBeVisible()
   })
 
   test('should display top agents ranking section', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Fix strict mode violation in E2E test: "Recently Added" now matches 2 elements (compact layout h3 + section h2)
- Use `.first()` to resolve ambiguity
- All 153 E2E tests passing

## Test plan

- [x] `npx playwright test` — 153 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)